### PR TITLE
Replace broken link with one to GH repo

### DIFF
--- a/doc/build.7.adoc
+++ b/doc/build.7.adoc
@@ -9,7 +9,7 @@ build - a description how to build GeckOS
 
 Building the object files for use on an OS/A65 machine should really
 be only a 'make', as long as my cross assembler xa
-http://www.tu-chemnitz.de/~fachat/8bit/cross/index.html"
+https://github.com/fachat/xa65
 is in the path.
 If there weren't these many options one can change.
 


### PR DESCRIPTION
Alternatively this could be replaced with `http://www.floodgap.com/retrotech/xa/`?